### PR TITLE
Generate valid URL when no transformations are provided

### DIFF
--- a/lib/imagekit/url.rb
+++ b/lib/imagekit/url.rb
@@ -80,7 +80,7 @@ class Url
     end
     transformation_str = transformation_to_str(options[:transformation]).chomp("/")
 
-    if transformation_str
+    unless transformation_str.blank?
       if (transformation_position == Default::QUERY_TRANSFORMATION_POSITION) || src_param_used_for_url == true
         result_url_hash[:query] = "#{Default::TRANSFORMATION_PARAMETER}=#{transformation_str}"
         query_params[:tr]=transformation_str

--- a/lib/imagekit/url.rb
+++ b/lib/imagekit/url.rb
@@ -80,7 +80,7 @@ class Url
     end
     transformation_str = transformation_to_str(options[:transformation]).chomp("/")
 
-    unless transformation_str.blank?
+    unless transformation_str.nil? || transformation_str.strip.empty?
       if (transformation_position == Default::QUERY_TRANSFORMATION_POSITION) || src_param_used_for_url == true
         result_url_hash[:query] = "#{Default::TRANSFORMATION_PARAMETER}=#{transformation_str}"
         query_params[:tr]=transformation_str


### PR DESCRIPTION
Reference: #14 (Specifying no transformation parameters generates invalid URL)