### PR TITLE
Do not force activestorage not carrierwave gem

### DIFF
--- a/imagekitio.gemspec
+++ b/imagekitio.gemspec
@@ -25,11 +25,10 @@ Gem::Specification.new do |spec|
 
   spec.files = Dir["{app,config,db,lib}/**/*", "MIT-LICENSE", "Rakefile", "README.md"]
 
-#  spec.add_dependency "rails", "~> 5.2.0", ">= 5.2.0"
-  spec.add_dependency 'carrierwave', '>= 0.7', '< 2.2'
-  spec.add_dependency 'rest-client', '~> 2.1', ">=2.1"
-  spec.add_dependency 'addressable', '~> 2.8'
-  spec.add_dependency 'activestorage', '>= 5.2.0'
-  spec.add_dependency 'multipart-post', '>= 2.1.0'
+  spec.add_dependency "addressable", "~> 2.8"
+  spec.add_dependency "multipart-post", ">= 2.1.0"
+  spec.add_dependency "rest-client", "~> 2.1", ">=2.1"
+  spec.add_development_dependency "activestorage", ">= 5.2.0"
+  spec.add_development_dependency "carrierwave", ">= 0.7", "< 2.2"
   spec.add_development_dependency "rails", "~> 5.2.0", ">= 5.2.0"
 end

--- a/lib/active_storage/active_storage.rb
+++ b/lib/active_storage/active_storage.rb
@@ -1,2 +1,7 @@
+begin
+  require 'active_storage'
+rescue LoadError
+  puts "Add gem 'activestorage' to use this service"
+end
 require_relative './service/ik_file'
 require_relative './service/image_kit_io_service'

--- a/lib/carrierwave/carrierwave.rb
+++ b/lib/carrierwave/carrierwave.rb
@@ -1,4 +1,8 @@
-require 'carrierwave'
+begin
+  require 'carrierwave'
+rescue LoadError
+  puts "Add gem 'carrierwave' to use this service"
+end
 require_relative './storage/imagekit_store'
 require_relative './storage/ik_file'
 require_relative './support/uri_filename'


### PR DESCRIPTION
It should be possible to use `imagekitio` gem within having both the `activestorage` and `carrierwave` gem to be installed.